### PR TITLE
update for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-dnanexus_normals_readcount_analysis_v1.2.1
+dnanexus_normals_readcount_analysis_v1.2.2
 Exome depth is run in two stages. Firstly, read counts are calculated and the second step filers out the CNVs of interest. Read counts are calculated over the entire genome and the CNVs are filtered out using a subpanel BED file.
 
 CNV calling can be performed by providing a readcount file for a set of known normals. 
 
-dnanexus_normals_readcount_analysis_v1.2.1 calculates readcounts for a panel of normals samples intended to use as an input for https://github.com/moka-guys/dnanexus_ED_readcount_analysis
+dnanexus_normals_readcount_analysis_v1.2.2 calculates readcounts for a panel of normals samples intended to use as an input for https://github.com/moka-guys/dnanexus_ED_readcount_analysis
 
 What does the app do?
 This app runs the read count calculation stage for a set of known normals.

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,10 +1,10 @@
 {
-  "name": "ED_panel_of_normals_v1.2.1",
-  "title": "ED_panel_of_normals_v1.2.1",
-  "summary": "v1.2.1 - Create panel of normals for cnv calling",
+  "name": "ED_panel_of_normals_v1.2.2",
+  "title": "ED_panel_of_normals_v1.2.2",
+  "summary": "v1.2.2 - Create panel of normals for cnv calling",
   "dxapi": "1.0.0",
   "properties": {
-    "github release": "v1.2.1"
+    "github release": "v1.2.2"
   },
   "inputSpec": [
     {
@@ -71,7 +71,7 @@
   },
   "ignoreReuse": false,
   "regionalOptions": {
-    "aws:eu-west-2-g": {
+    "aws:us-east-1": {
       "systemRequirements": {
         "*": {
           "instanceType": "mem1_ssd1_v2_x4"

--- a/src/code.sh
+++ b/src/code.sh
@@ -74,7 +74,7 @@ cd /home/dnanexus
 
 mark-section "setting up Exomedepth docker image"
 # Location of the ExomeDepth docker file
-docker_file_id=project-J32193pK9yGfjP2GyZ94KZf4:file-J342zpXK9yGxz8zxBKygQq80
+docker_file_id=project-ByfFPz00jy1fk6PjpZ95F27J:file-J2gVVb005gg4By325qjqQQz6
 # download the docker file from 001_Tools...
 dx download $docker_file_id --auth "${API_KEY}"
 docker_file=$(dx describe ${docker_file_id} --name)


### PR DESCRIPTION
This is to update the app to use the docker image v2.2.0 of seglh-cnv (https://github.com/moka-guys/seglh-cnv). ED CNV caller app is going to use v2.2.0 docker image. To be consistent with ED CNV caller, the normals_readcount app should also use the same version v2.2.0.

Changes:

update docker image file ID for v2.2.0
update the region code since the most recent release main branch was for London region code. This update is for US region code.